### PR TITLE
Add parsing support for imported modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ identifier      := identifier-head { identifier-tail }
 identifier-head := "a" ... "z" | "A" ... "Z" | "_"
 identifier-tail := identifier-head | "0" ... "9"
 
-directive      := load-directive | link-directive
-load-directive := "#load" string-literal
-link-directive := "#link" string-literal
+directive        := load-directive | link-directive | import-directive
+load-directive   := "#load" string-literal
+link-directive   := "#link" string-literal
+import-directive := "#import" string-literal
 
 block := '{' { statement } '}'
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ constant-expression := nil-literal | bool-literal | numeric-literal | string-lit
 nil-literal         := "nil"
 bool-literal        := "true" | "false"
 
+module-declaration := "module" identifier "{" [ { load-directive | link-directive } ] "}"
+
 enum-declaration := "enum" identifier "{" [ enum-element { line-break enum-element } ] "}"
 
 func-declaration := "func" identifier "(" [ parameter-declaration { "," parameter-declaration } ] ")" "->" type-identifier block
@@ -124,5 +126,6 @@ pointer-type             := type "*"
 array-type               := type "[" [ expression ] "]"
 function-pointer-type    := "(" [ type { "," type } ] ")" "->" type
 
-top-level-node := load-declaration | enum-declaration | func-declaration | struct-declaration | variable-declaration
+top-level-node := directive | enum-declaration | func-declaration | struct-declaration | variable-declaration
+top-level-interface-node := load-directive | link-directive | enum-declaration | foreing-func-declaration | struct-declaration | variable-declaration | type-alias
 ```

--- a/README.md
+++ b/README.md
@@ -86,10 +86,6 @@ prefix-operator  := '!' | '~' | '+' | '-'
 expression        := binary-expression | primary-expression
 binary-expression := primary-expression infix-operator expression
 
-identifier := identifier-head { identifier-tail }
-identifier-head := "a" ... "z" | "A" ... "Z" | "_"
-identifier-tail := identifier-head | "0" ... "9"
-
 call-expression := expression "(" [ expression { "," expression } ] ")"
 
 constant-expression := nil-literal | bool-literal | numeric-literal | string-literal

--- a/include/JellyCore/ASTContext.h
+++ b/include/JellyCore/ASTContext.h
@@ -33,6 +33,8 @@ ASTLoadDirectiveRef ASTContextCreateLoadDirective(ASTContextRef context, SourceR
 
 ASTLinkDirectiveRef ASTContextCreateLinkDirective(ASTContextRef context, SourceRange location, ASTScopeRef scope, StringRef library);
 
+ASTImportDirectiveRef ASTContextCreateImportDirective(ASTContextRef context, SourceRange location, ASTScopeRef scope, StringRef modulePath);
+
 ASTBlockRef ASTContextCreateBlock(ASTContextRef context, SourceRange location, ASTScopeRef scope, ArrayRef statements);
 
 ASTIfStatementRef ASTContextCreateIfStatement(ASTContextRef context, SourceRange location, ASTScopeRef scope, ASTExpressionRef condition,

--- a/include/JellyCore/ASTNodes.h
+++ b/include/JellyCore/ASTNodes.h
@@ -19,6 +19,7 @@ enum _ASTTag {
     ASTTagArray,
     ASTTagLoadDirective,
     ASTTagLinkDirective,
+    ASTTagImportDirective,
     ASTTagBlock,
     ASTTagIfStatement,
     ASTTagLoopStatement,
@@ -91,6 +92,7 @@ typedef struct _ASTSourceUnit *ASTSourceUnitRef;
 typedef struct _ASTLinkedList *ASTLinkedListRef;
 typedef struct _ASTLoadDirective *ASTLoadDirectiveRef;
 typedef struct _ASTLinkDirective *ASTLinkDirectiveRef;
+typedef struct _ASTImportDirective *ASTImportDirectiveRef;
 typedef struct _ASTBlock *ASTBlockRef;
 typedef struct _ASTTypeAliasDeclaration *ASTTypeAliasDeclarationRef;
 typedef struct _ASTIfStatement *ASTIfStatementRef;
@@ -175,6 +177,12 @@ struct _ASTLinkDirective {
     struct _ASTNode base;
 
     StringRef library;
+};
+
+struct _ASTImportDirective {
+    struct _ASTNode base;
+
+    StringRef modulePath;
 };
 
 struct _ASTBlock {

--- a/include/JellyCore/Lexer.h
+++ b/include/JellyCore/Lexer.h
@@ -97,6 +97,7 @@ enum _TokenKind {
     TokenKindDirectiveLink,
     TokenKindDirectiveIntrinsic,
     TokenKindDirectiveForeign,
+    TokenKindDirectiveImport,
     TokenKindLiteralString,
     TokenKindLiteralInt,
     TokenKindLiteralFloat,

--- a/include/JellyCore/Lexer.h
+++ b/include/JellyCore/Lexer.h
@@ -93,6 +93,7 @@ enum _TokenKind {
     TokenKindKeywordFloat32,
     TokenKindKeywordFloat64,
     TokenKindKeywordFloat,
+    TokenKindKeywordModule,
     TokenKindDirectiveLoad,
     TokenKindDirectiveLink,
     TokenKindDirectiveIntrinsic,

--- a/include/JellyCore/Parser.h
+++ b/include/JellyCore/Parser.h
@@ -14,6 +14,8 @@ ParserRef ParserCreate(AllocatorRef allocator, ASTContextRef context);
 void ParserDestroy(ParserRef parser);
 
 ASTSourceUnitRef ParserParseSourceUnit(ParserRef parser, StringRef filePath, StringRef source);
+ASTSourceUnitRef ParserParseModuleSourceUnit(ParserRef parser, ASTModuleDeclarationRef module, StringRef filePath, StringRef source);
+ASTModuleDeclarationRef ParserParseModuleDeclaration(ParserRef parser, StringRef filePath, StringRef source);
 
 JELLY_EXTERN_C_END
 

--- a/lib/JellyCore/ASTContext.c
+++ b/lib/JellyCore/ASTContext.c
@@ -38,6 +38,7 @@ ASTContextRef ASTContextCreate(AllocatorRef allocator, StringRef moduleName) {
     context->nodes[ASTTagArray]                   = ArrayCreateEmpty(context->allocator, sizeof(struct _ASTArray), 2048);
     context->nodes[ASTTagLoadDirective]           = ArrayCreateEmpty(context->allocator, sizeof(struct _ASTLoadDirective), 1024);
     context->nodes[ASTTagLinkDirective]           = ArrayCreateEmpty(context->allocator, sizeof(struct _ASTLinkDirective), 1024);
+    context->nodes[ASTTagImportDirective]         = ArrayCreateEmpty(context->allocator, sizeof(struct _ASTImportDirective), 1024);
     context->nodes[ASTTagBlock]                   = ArrayCreateEmpty(context->allocator, sizeof(struct _ASTBlock), 1024);
     context->nodes[ASTTagTypeAliasDeclaration]    = ArrayCreateEmpty(context->allocator, sizeof(struct _ASTTypeAliasDeclaration), 1024);
     context->nodes[ASTTagIfStatement]             = ArrayCreateEmpty(context->allocator, sizeof(struct _ASTIfStatement), 1024);
@@ -140,6 +141,15 @@ ASTLinkDirectiveRef ASTContextCreateLinkDirective(ASTContextRef context, SourceR
 
     ASTLinkDirectiveRef node = (ASTLinkDirectiveRef)_ASTContextCreateNode(context, ASTTagLinkDirective, location, scope);
     node->library            = StringCreateCopy(context->allocator, library);
+    return node;
+}
+
+ASTImportDirectiveRef ASTContextCreateImportDirective(ASTContextRef context, SourceRange location, ASTScopeRef scope,
+                                                      StringRef modulePath) {
+    assert(modulePath);
+
+    ASTImportDirectiveRef node = (ASTImportDirectiveRef)_ASTContextCreateNode(context, ASTTagImportDirective, location, scope);
+    node->modulePath           = StringCreateCopy(context->allocator, modulePath);
     return node;
 }
 

--- a/lib/JellyCore/ASTDumper.c
+++ b/lib/JellyCore/ASTDumper.c
@@ -225,11 +225,16 @@ void ASTDumperDump(ASTDumperRef dumper, ASTNodeRef node) {
         return;
     }
 
+    case ASTTagForeignFunctionDeclaration:
     case ASTTagFunctionDeclaration: {
         ASTFunctionDeclarationRef func = (ASTFunctionDeclarationRef)node;
         _ASTDumperPrintProperty(dumper, "name", StringGetCharacters(func->base.name));
         _ASTDumperDumpChildrenArray(dumper, func->parameters);
         _ASTDumperDumpChild(dumper, func->returnType);
+
+        if (func->base.base.tag == ASTTagForeignFunctionDeclaration) {
+            _ASTDumperPrintProperty(dumper, "foreignName", StringGetCharacters(func->foreignName));
+        }
 
         if (func->body) {
             _ASTDumperDumpChild(dumper, (ASTNodeRef)func->body);
@@ -430,6 +435,9 @@ static inline void _ASTDumperPrintTag(ASTDumperRef dumper, ASTNodeRef node) {
 
     case ASTTagEnumerationDeclaration:
         return _ASTDumperPrintCString(dumper, "EnumerationDeclaration");
+
+    case ASTTagForeignFunctionDeclaration:
+        return _ASTDumperPrintCString(dumper, "ForeignFunctionDeclaration");
 
     case ASTTagFunctionDeclaration:
         return _ASTDumperPrintCString(dumper, "FunctionDeclaration");

--- a/lib/JellyCore/ASTDumper.c
+++ b/lib/JellyCore/ASTDumper.c
@@ -50,6 +50,12 @@ void ASTDumperDump(ASTDumperRef dumper, ASTNodeRef node) {
         return;
     }
 
+    case ASTTagImportDirective: {
+        ASTImportDirectiveRef import = (ASTImportDirectiveRef)node;
+        _ASTDumperPrintProperty(dumper, "modulePath", StringGetCharacters(import->modulePath));
+        return;
+    }
+
     case ASTTagBlock: {
         ASTBlockRef block = (ASTBlockRef)node;
         _ASTDumperDumpChildrenArray(dumper, block->statements);
@@ -332,6 +338,9 @@ static inline void _ASTDumperPrintTag(ASTDumperRef dumper, ASTNodeRef node) {
 
     case ASTTagLoadDirective:
         return _ASTDumperPrintCString(dumper, "LoadDirective");
+
+    case ASTTagImportDirective:
+        return _ASTDumperPrintCString(dumper, "ImportDirective");
 
     case ASTTagBlock:
         return _ASTDumperPrintCString(dumper, "Block");

--- a/lib/JellyCore/ASTSubstitution.c
+++ b/lib/JellyCore/ASTSubstitution.c
@@ -68,6 +68,10 @@ static inline void _ASTApplySubstitution(ASTContextRef context, ASTNodeRef node)
         return;
     }
 
+    if (node->tag == ASTTagImportDirective) {
+        return;
+    }
+
     if (node->tag == ASTTagBlock) {
         ASTBlockRef block = (ASTBlockRef)node;
         _ASTApplySubstitutionInplace(context, block->statements, ASTArrayRef);

--- a/lib/JellyCore/Compiler.c
+++ b/lib/JellyCore/Compiler.c
@@ -10,6 +10,8 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+// TODO: @ModuleSupport Add compilation support of modules
+
 Int CompilerRun(ArrayRef arguments) {
     Int32 argc  = ArrayGetElementCount(arguments);
     Char **argv = AllocatorAllocate(AllocatorGetSystemDefault(), sizeof(Char *) * argc);

--- a/lib/JellyCore/IRBuilder.c
+++ b/lib/JellyCore/IRBuilder.c
@@ -141,6 +141,7 @@ IRModuleRef IRBuilderBuild(IRBuilderRef builder, ASTModuleDeclarationRef module)
 
             switch (child->tag) {
             case ASTTagLoadDirective:
+            case ASTTagImportDirective:
                 continue;
 
             case ASTTagEnumerationDeclaration:

--- a/lib/JellyCore/Lexer.c
+++ b/lib/JellyCore/Lexer.c
@@ -749,6 +749,8 @@ static inline TokenKind _LexerLexIdentifierOrKeyword(LexerRef lexer) {
         kind = TokenKindKeywordFloat64;
     } else if (SourceRangeIsEqual(range, "Float")) {
         kind = TokenKindKeywordFloat;
+    } else if (SourceRangeIsEqual(range, "module")) {
+        kind = TokenKindKeywordModule;
     } else {
         kind = TokenKindIdentifier;
     }

--- a/lib/JellyCore/Lexer.c
+++ b/lib/JellyCore/Lexer.c
@@ -582,6 +582,8 @@ static inline TokenKind _LexerLexDirective(LexerRef lexer) {
         kind = TokenKindDirectiveIntrinsic;
     } else if (SourceRangeIsEqual(range, "foreign")) {
         kind = TokenKindDirectiveForeign;
+    } else if (SourceRangeIsEqual(range, "import")) {
+        kind = TokenKindDirectiveImport;
     }
 
     return kind;

--- a/lib/JellyCore/NameResolution.c
+++ b/lib/JellyCore/NameResolution.c
@@ -3,6 +3,7 @@
 #include "JellyCore/Diagnostic.h"
 #include "JellyCore/NameResolution.h"
 
+// TODO: @ModuleSupport Add name resolution support for imported modules
 // TODO: @Bug Type all enumeration elements with the enumeration type and replace it with lowered int type in the backend
 
 enum _CandidateFunctionMatchKind {
@@ -111,7 +112,7 @@ void PerformNameResolution(ASTContextRef context, ASTModuleDeclarationRef module
 
             if (child->tag == ASTTagStructureDeclaration) {
                 ASTStructureDeclarationRef structure = (ASTStructureDeclarationRef)child;
-                ASTArrayIteratorRef iterator = ASTArrayGetIterator(structure->initializers);
+                ASTArrayIteratorRef iterator         = ASTArrayGetIterator(structure->initializers);
                 while (iterator) {
                     ASTInitializerDeclarationRef initializer = (ASTInitializerDeclarationRef)ASTArrayIteratorGetElement(iterator);
                     _PerformNameResolutionForNode(context, (ASTNodeRef)initializer->body);

--- a/lib/JellyCore/TypeChecker.c
+++ b/lib/JellyCore/TypeChecker.c
@@ -124,7 +124,8 @@ static inline void _TypeCheckerValidateSourceUnit(TypeCheckerRef typeChecker, AS
 }
 
 static inline void _TypeCheckerValidateTopLevelNode(TypeCheckerRef typeChecker, ASTContextRef context, ASTNodeRef node) {
-    if (node->tag == ASTTagLoadDirective || node->tag == ASTTagLinkDirective || node->tag == ASTTagTypeAliasDeclaration) {
+    if (node->tag == ASTTagLoadDirective || node->tag == ASTTagLinkDirective || node->tag == ASTTagImportDirective ||
+        node->tag == ASTTagTypeAliasDeclaration) {
         return;
     }
 

--- a/test/parser/import_directive.dump
+++ b/test/parser/import_directive.dump
@@ -1,5 +1,41 @@
 ModuleDeclaration
+  ModuleDeclaration
+    SourceUnit
+      @filePath = 'test_module/my_module.jelly'
+      LoadDirective
+        @sourceFilePath = 'sourceFile0.jelly'
+    SourceUnit
+      @filePath = 'test_module/sourceFile0.jelly'
+      LoadDirective
+        @sourceFilePath = 'sourceFile1.jelly'
+      ForeignFunctionDeclaration
+        @name = 'myForeignFunc'
+        BuiltinType
+          @name = 'Void'
+        @foreignName = 'myForeignFunc'
+    SourceUnit
+      @filePath = 'test_module/sourceFile1.jelly'
+      StructureDeclaration
+        @name = 'Point'
+        VariableDeclaration
+          @name = 'x'
+          BuiltinType
+            @name = 'Int'
+        VariableDeclaration
+          @name = 'y'
+          BuiltinType
+            @name = 'Int'
+      ForeignFunctionDeclaration
+        @name = 'myLocation'
+        OpaqueType
+          @name = 'Point'
+        @foreignName = 'myLocation'
+  ModuleDeclaration
+    SourceUnit
+      @filePath = 'test_module/my_same_module.jelly'
   SourceUnit
     @filePath = 'import_directive.jelly'
     ImportDirective
       @modulePath = 'test_module/my_module.jelly'
+    ImportDirective
+      @modulePath = 'test_module/my_same_module.jelly'

--- a/test/parser/import_directive.dump
+++ b/test/parser/import_directive.dump
@@ -1,0 +1,5 @@
+ModuleDeclaration
+  SourceUnit
+    @filePath = 'import_directive.jelly'
+    ImportDirective
+      @modulePath = 'test_module/my_module.jelly'

--- a/test/parser/import_directive.jelly
+++ b/test/parser/import_directive.jelly
@@ -1,0 +1,1 @@
+#import "test_module/my_module.jelly"

--- a/test/parser/import_directive.jelly
+++ b/test/parser/import_directive.jelly
@@ -1,1 +1,2 @@
 #import "test_module/my_module.jelly"
+#import "test_module/my_same_module.jelly" // expect-error: Module 'MyModule' cannot be imported twice

--- a/test/parser/test_module/my_module.jelly
+++ b/test/parser/test_module/my_module.jelly
@@ -1,0 +1,6 @@
+module MyModule {
+    #load "sourceFile0.jelly"
+    #load "sourceFile1.jelly"
+    #link "library1"
+    #link "library2"
+}

--- a/test/parser/test_module/my_same_module.jelly
+++ b/test/parser/test_module/my_same_module.jelly
@@ -1,0 +1,2 @@
+module MyModule {
+}

--- a/test/parser/test_module/sourceFile0.jelly
+++ b/test/parser/test_module/sourceFile0.jelly
@@ -1,0 +1,3 @@
+#load "sourceFile1.jelly"
+
+#foreign func myForeignFunc() -> Void "myForeignFunc"

--- a/test/parser/test_module/sourceFile1.jelly
+++ b/test/parser/test_module/sourceFile1.jelly
@@ -1,0 +1,6 @@
+struct Point {
+    var x: Int
+    var y: Int
+}
+
+#foreign func myLocation() -> Point "myLocation"

--- a/test/parser/unexpected_consecutive_declarations_on_a_line.jelly
+++ b/test/parser/unexpected_consecutive_declarations_on_a_line.jelly
@@ -1,1 +1,3 @@
-struct Test { var x: Int var y: Int } // expect-error: Consecutive statements on a line are not allowed
+struct Test { 
+    var x: Int var y: Int // expect-error: Consecutive statements on a line are not allowed
+} 

--- a/test/sema/invalid_func_decl_in_struct_body.jelly
+++ b/test/sema/invalid_func_decl_in_struct_body.jelly
@@ -1,7 +1,7 @@
 // run: -type-check
 
 struct A {
-    func myFunc() -> Void {} // expect-error: Expected keyword 'var' or 'init' in structure body
+    func myFunc() -> Void {} // expect-error: Expected 'var' or 'init' in structure body
 }
 
 func main() -> Void {}

--- a/test/sema/invalid_struct_in_struct_body.jelly
+++ b/test/sema/invalid_struct_in_struct_body.jelly
@@ -1,7 +1,7 @@
 // run: -type-check
 
 struct A {
-    struct B {} // expect-error: Expected 'var' found 'struct'
+    struct B {} // expect-error: Expected 'var' or 'init' in structure body
 }
 
 func main() -> Void {}

--- a/test/sema/module_import.jelly
+++ b/test/sema/module_import.jelly
@@ -1,0 +1,5 @@
+// run: -type-check
+
+#import "test_module/TestModule.jelly"
+
+func main() -> Void {}

--- a/test/sema/test_module/TestModule.jelly
+++ b/test/sema/test_module/TestModule.jelly
@@ -1,5 +1,6 @@
-module MyModule {
+module TestModule {
     #load "sourceFile0.jelly"
+    #load "sourceFile1.jelly"
     #link "library1"
     #link "library2"
 }

--- a/test/sema/test_module/sourceFile0.jelly
+++ b/test/sema/test_module/sourceFile0.jelly
@@ -1,0 +1,1 @@
+#foreign func min(lhs: Int, rhs: Int) -> Int "min"

--- a/test/sema/test_module/sourceFile1.jelly
+++ b/test/sema/test_module/sourceFile1.jelly
@@ -1,0 +1,1 @@
+#foreign func max(lhs: Int, rhs: Int) -> Int "max"

--- a/test/src/LexerTests.cpp
+++ b/test/src/LexerTests.cpp
@@ -874,6 +874,10 @@ static inline void _PrintTokenKindDescription(TokenKind kind) {
             printf("%s", "Float");
             break;
 
+        case TokenKindKeywordModule:
+            printf("%s", "module");
+            break;
+
         case TokenKindDirectiveLoad:
             printf("%s", "#load");
             break;

--- a/test/src/LexerTests.cpp
+++ b/test/src/LexerTests.cpp
@@ -890,6 +890,10 @@ static inline void _PrintTokenKindDescription(TokenKind kind) {
             printf("%s", "#foreign");
             break;
 
+        case TokenKindDirectiveImport:
+            printf("%s", "#import");
+            break;
+
         case TokenKindLiteralString:
             printf("%s", "STRING");
             break;


### PR DESCRIPTION
There is still some work missing to complete this feature but those will not be implemented yet due to possible internal compiler restructuring...

Missing features:
- The name resolution phase has to support imported module lookups
- The compiler has to allow the compilation of modules emitting the target library and module interface files
- Declaration interface collisions have to be checked for all modules in the semantic analysis phase
- Calling convention support has to be added to #foreign directive
- ABI support for parameters and return types has to be guaranteed based on calling convention